### PR TITLE
/nick command was still being displayed in /commands output.

### DIFF
--- a/src/alpha/plugCubed/dialogs/Commands.js
+++ b/src/alpha/plugCubed/dialogs/Commands.js
@@ -1,6 +1,5 @@
 define(['jquery', 'plugCubed/Class', 'plugCubed/Lang', 'plugCubed/Utils'], function($, Class, p3Lang, p3Utils) {
     var userCommands = [
-        ['/nick', 'commands.descriptions.nick'],
         ['/avail', 'commands.descriptions.avail'],
         ['/afk', 'commands.descriptions.afk'],
         ['/work', 'commands.descriptions.work'],


### PR DESCRIPTION
This line still caused the /nick command to appear in the /commands help text. I didn't notice this one before and didn't really know of an easy way to test my own version, since chrome doesn't want to load JS locally nor from anything but https. 
