### PR TITLE
Use local version of plugCubed.js in Firefox extension

### DIFF
--- a/extensions/Firefox/data/loader.js
+++ b/extensions/Firefox/data/loader.js
@@ -1,27 +1,16 @@
-var s, loader = function() {
-    var a = {
-        b: function() {
-            if (typeof API !== 'undefined' && API.enabled)
-                this.c(); else
-                setTimeout(function() {
-                    a.b();
-                }, 100);
-        },
-        c: function() {
-            console.log('plugCubed Firefox Loader v.0.1 enabled!');
-            var plug = document.createElement('script');
-            plug.type = 'text/javascript';
-            plug.src = 'https://d1rfegul30378.cloudfront.net/files/plugCubed.js';
-            document.head.appendChild(plug);
-            var load = document.getElementById('firefoxP3Loader');
-            load.parentNode.removeChild(load);
-        }
-    };
-    a.b();
-};
+var load = function() {
+    console.log('plugCubed Firefox Loader v.0.1 enabled!');
+    var plug = document.createElement('script');
+    plug.type = 'text/javascript';
+    plug.src = self.options.main_js;
+    document.head.appendChild(plug);
+}
 
-s = document.createElement('script');
-s.type = 'text/javascript';
-s.id = 'firefoxP3Loader';
-s.text = '(' + loader.toString() + ')();';
-document.head.appendChild(s);
+var wait = function retry() {
+    if (typeof unsafeWindow.API !== 'undefined' && unsafeWindow.API.enabled) load();
+    else setTimeout(function() {
+            retry();
+        }, 100);
+}
+
+wait();

--- a/extensions/Firefox/lib/main.js
+++ b/extensions/Firefox/lib/main.js
@@ -10,5 +10,9 @@ pageMod.PageMod({
         'https://plug.dj/privacy',
         'https://plug.dj/logout',
         'https://plug.dj/'],
-    contentScriptFile: self.data.url('loader.js')
+    attachTo: 'top',
+    contentScriptFile: self.data.url('loader.js'),
+    contentScriptOptions: {
+        main_js: self.data.url('plugCubed.js'),
+    }
 });


### PR DESCRIPTION
The included file has to be in `/data/plugCubed.js` before the extension is built. Only the main script gets loaded from /data, because once the script is running in the page context, it doesn't have access to the plugin resources any more. I also used the unsafeWindow object to check if the API is loaded, which according to MDN isn't a supported API and could change in the future, but they don't recommend an alternative, so I have to keep using it.
