### PR TITLE
Fix autojoin

### DIFF
--- a/src/alpha/plugCubed/features/Autojoin.js
+++ b/src/alpha/plugCubed/features/Autojoin.js
@@ -3,36 +3,21 @@ define(['plugCubed/handlers/TriggerHandler', 'plugCubed/Settings', 'plugCubed/Ro
 
     join = function() {
         var dj = API.getDJ();
-        if ((dj !== null && dj.id == API.getUser().id) || API.getWaitListPosition() > -1 || API.getWaitList().length == 50) return;
+        var userId = API.getUser().id;
+        if ((dj !== null && dj.id == userId) || API.getWaitListPosition() > -1 ||
+          API.getWaitList().length == 50 || this.lastDJ == userId) return;
         $('#dj-button').click();
     };
 
     handler = TriggerHandler.extend({
         trigger: {
             advance: 'onDjAdvance',
-            waitListUpdate: 'onWaitListUpdate',
             chat: 'onChat'
         },
         onDjAdvance: function(data) {
             this.lastDJ = data.lastPlay.dj != null ? data.lastPlay.dj.id : null;
             if (!Settings.autojoin || !RoomSettings.rules.allowAutojoin) return;
             join();
-        },
-        onWaitListUpdate: function() {
-            // If autojoin is not enabled, don't try to disable
-            if (!Settings.autojoin) return;
-            // If user is DJing, don't try to disable
-            var dj = API.getDJ();
-            if (dj !== null && dj.id === API.getUser().id) return;
-            // If user is in waitlist, don't try to disable
-            if (API.getWaitListPosition() > -1) return;
-            // If waitlist is full, don't try to disable
-            if (API.getWaitList().length == 50) return;
-            // If user was last DJ (DJ Cycle Disabled)
-            if (this.lastDJ == API.getUser().id) return;
-            // Disable
-            Settings.autojoin = false;
-            Menu.setEnabled('join', Settings.autojoin);
         },
         onChat: function(data) {
             if (!(RoomSettings.rules.allowAutojoin !== false && Settings.autojoin))

--- a/src/alpha/plugCubed/features/Autojoin.js
+++ b/src/alpha/plugCubed/features/Autojoin.js
@@ -17,7 +17,7 @@ define(['plugCubed/handlers/TriggerHandler', 'plugCubed/Settings', 'plugCubed/Ro
         onDjAdvance: function(data) {
             this.lastDJ = data.lastPlay.dj != null ? data.lastPlay.dj.id : null;
             if (!Settings.autojoin || !RoomSettings.rules.allowAutojoin) return;
-            join();
+            join.call(this);
         },
         onChat: function(data) {
             if (!(RoomSettings.rules.allowAutojoin !== false && Settings.autojoin))


### PR DESCRIPTION
As far as I can tell, this method does nothing except break the autojoin feature.  The logic is completely backwards...it checks all the cases where you wouldn't want autojoin, and then if none of them are true, it DISABLES autojoin altogether.  I'm not sure what the purpose of that method was originally supposed to be, but removing it with the other changes added in creates a working autojoin.  I tested this script in Chillout Music with success.

Here's a fixed compiled script for testing:

https://rawgit.com/elwayman02/017aa8569d2ed6f0fe48/raw/d327b6ce603ab2145740f7240969817c9915d526/plugCubed.js