### PR TITLE
prevent html2text loading resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We welcome all contributions to this project.
 * Make a fork of this repository.
 * Clone the forked repository to an empty folder.
 * Cd to the folder through command prompt or bash
-* Run `npm install` to set up the environment.
+* Run `npm install --only=dev` to set up the environment.
 * Make your changes in the src/alpha folder and please make sure you follow our [Code Style](https://github.com/plugCubed/Code-Style).
 * Run `gulp build:alpha` to compile the code and test with `gulp test:alpha`. (If `gulp` doesn't work, please install it by typing `npm install -g gulp-cli` in commandline)
 * Submit your changes as a Pull Requests [here](https://github.com/plugCubed/plugCubed/pulls).

--- a/src/alpha/plugCubed/Utils.js
+++ b/src/alpha/plugCubed/Utils.js
@@ -1,5 +1,5 @@
 define(['plugCubed/Class', 'plugCubed/Lang', 'plugCubed/ModuleLoader'], function(Class, p3Lang) {
-    var cleanHTMLMessage, Database, developer, sponsor, ambassador, donatorDiamond, donatorPlatinum, donatorGold, donatorSilver, donatorBronze, special, Lang, PlugUI, PopoutView;
+    var cleanHTMLMessage, Database, developer, sponsor, ambassador, donatorDiamond, donatorPlatinum, donatorGold, donatorSilver, donatorBronze, special, Lang, PlugUI, PopoutView, sandbox, html2text;
 
     if (typeof window.plugCubedUserData === 'undefined') {
         window.plugCubedUserData = {};
@@ -54,6 +54,19 @@ define(['plugCubed/Class', 'plugCubed/Lang', 'plugCubed/ModuleLoader'], function
                 donatorBronze = data.donator.bronze ? data.donator.bronze : [];
             }
         });
+
+    html2text = function(html) {
+        if (!html) return '';
+
+        if (!sandbox) {
+            sandbox = document.implementation.createHTMLDocument('p3-sandbox');
+        }
+        var tmp = sandbox.createElement('div');
+
+        tmp.innerHTML = html;
+
+        return tmp.textContent || tmp.text || tmp.innerText;
+    };
 
     var Handler = Class.extend({
         proxifyImage: function(url) {
@@ -298,9 +311,7 @@ define(['plugCubed/Class', 'plugCubed/Lang', 'plugCubed/ModuleLoader'], function
             return special[uid];
         },
         html2text: function(html) {
-            if (!html) return '';
-
-            return $('<div/>').html(html).text();
+            return html2text(html);
         },
         cleanHTML: function(msg, disallow, extraAllow) {
             return cleanHTMLMessage(msg, disallow, extraAllow);

--- a/src/alpha/plugCubed/Utils.js
+++ b/src/alpha/plugCubed/Utils.js
@@ -64,7 +64,7 @@ define(['plugCubed/Class', 'plugCubed/Lang', 'plugCubed/ModuleLoader'], function
             return url;
         },
         escapeRegex: function(text) {
-            return text.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+            return text.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
         },
         getHighestRank: function(uid) {
             if (!uid) {
@@ -912,4 +912,3 @@ define(['plugCubed/Class', 'plugCubed/Lang', 'plugCubed/ModuleLoader'], function
 
     return new Handler();
 });
-

--- a/src/alpha/plugCubed/Utils.js
+++ b/src/alpha/plugCubed/Utils.js
@@ -1,5 +1,5 @@
 define(['plugCubed/Class', 'plugCubed/Lang', 'plugCubed/ModuleLoader'], function(Class, p3Lang) {
-    var cleanHTMLMessage, Database, developer, sponsor, ambassador, donatorDiamond, donatorPlatinum, donatorGold, donatorSilver, donatorBronze, special, Lang, PlugUI, PopoutView, sandbox, html2text;
+    var cleanHTMLMessage, Database, developer, sponsor, ambassador, donatorDiamond, donatorPlatinum, donatorGold, donatorSilver, donatorBronze, special, Lang, PlugUI, PopoutView, html2text;
 
     if (typeof window.plugCubedUserData === 'undefined') {
         window.plugCubedUserData = {};
@@ -58,14 +58,31 @@ define(['plugCubed/Class', 'plugCubed/Lang', 'plugCubed/ModuleLoader'], function
     html2text = function(html) {
         if (!html) return '';
 
-        if (!sandbox) {
-            sandbox = document.implementation.createHTMLDocument('p3-sandbox');
+        var doc;
+
+        // use DOMParser for html
+        try {
+            var parser = new DOMParser();
+
+            doc = parser.parseFromString(html, 'text/html');
+        } catch (ex) { /* noop */ }
+
+        // fallback to document.implementation
+        if (!doc) {
+            try {
+                doc = document.implementation.createHTMLDocument('');
+                if (/<\/?(html|head|body)[>]*>/gi.test(html)) {
+                    doc.documentElement.innerHTML = html;
+                } else {
+                    doc.body.innerHTML = html;
+                }
+            } catch (ex2) { /* noop */ }
         }
-        var tmp = sandbox.createElement('div');
 
-        tmp.innerHTML = html;
+        if (doc) return doc.body.textContent || doc.body.text || doc.body.innerText;
 
-        return tmp.textContent || tmp.text || tmp.innerText;
+        // fallback to old method (warnings on mixed content)
+        return $('<div/>').html(html).text();
     };
 
     var Handler = Class.extend({


### PR DESCRIPTION
using the html2text function will attempt to load resources contained in the string, which will cause errors in console if the are mixed content.

by using a sanboxed document implementation we can bypass this by preventing resource loading.

![example error](https://i.imgur.com/d6uM4jc.png)